### PR TITLE
Require Node 20 for Vite

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ This is a simple prototype demonstrating the Overlord sprite.
 
 ## Development
 
-Install dependencies and start the dev server:
+Install dependencies and start the dev server. Node.js 20 or newer is
+required by Vite 7, so make sure your environment is up to date:
 
 ```bash
 npm install

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
   "author": "",
   "license": "ISC",
   "type": "module",
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "devDependencies": {
     "typescript": "^5.8.3",
     "vite": "^7.0.4",


### PR DESCRIPTION
## Summary
- document that Vite 7 needs Node.js 20+
- enforce Node 20+ via `engines` in package.json

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68753e56dc0c832ba701a739748c18ac