### PR TITLE
Fix Overlord.json reload with Vite

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import { parseFrames, Frame } from './frame-utils';
+import overlordData from '../public/Overlord.json';
 
 const canvas = document.getElementById('game') as HTMLCanvasElement;
 const ctx = canvas.getContext('2d')!;
@@ -33,15 +34,14 @@ function draw(timestamp: number) {
 }
 
 Promise.all([
-  fetch('/Overlord.json').then(r => r.json()),
   new Promise<void>(resolve => {
     spriteSheet.onload = () => resolve();
   }),
   new Promise<void>(resolve => {
     background.onload = () => resolve();
   })
-]).then(([data]) => {
-  frames = parseFrames(data);
+]).then(() => {
+  frames = parseFrames(overlordData);
   canvas.width = background.width;
   canvas.height = background.height;
   function resizeCanvas() {


### PR DESCRIPTION
## Summary
- import `Overlord.json` directly
- parse that data after images load

## Testing
- `npm test`
- `npx vite build`


------
https://chatgpt.com/codex/tasks/task_e_687598669570832b889341228a82613a