### PR TITLE
Add dialog system with Yarn file

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,10 @@
 </head>
 <body>
   <canvas id="game"></canvas>
+  <div id="dialogue" style="position:absolute;bottom:0;left:0;width:100%;background:rgba(0,0,0,0.8);color:#fff;font-family:sans-serif;padding:10px;">
+    <div id="dialogue-text"></div>
+    <div id="dialogue-options" style="margin-top:8px;"></div>
+  </div>
   <script type="module" src="/src/main.ts"></script>
 </body>
 </html>

--- a/src/dialog-manager.ts
+++ b/src/dialog-manager.ts
@@ -1,0 +1,111 @@
+export interface DialogueOption {
+  text: string;
+  target: string | null;
+}
+
+export interface DialogueContent {
+  lines: string[];
+  options: DialogueOption[];
+  next: string | null;
+}
+
+import { parseYarn, YarnNode } from './yarn-utils';
+
+export class DialogManager {
+  private nodes: Record<string, YarnNode> = {};
+  private visited = new Set<string>();
+  private current: string | null = null;
+
+  constructor(yarnText: string) {
+    const nodes = parseYarn(yarnText);
+    for (const n of nodes) {
+      this.nodes[n.title] = n;
+    }
+  }
+
+  start(startNode: string) {
+    this.goto(startNode);
+  }
+
+  goto(nodeName: string | null) {
+    if (!nodeName || !this.nodes[nodeName]) return;
+    this.current = nodeName;
+    this.visited.add(nodeName);
+  }
+
+  getCurrent(): DialogueContent {
+    if (!this.current) return { lines: [], options: [], next: null };
+    return parseNodeBody(this.nodes[this.current].body, this.visited);
+  }
+
+  choose(index: number) {
+    const content = this.getCurrent();
+    const opt = content.options[index];
+    if (opt) {
+      this.goto(opt.target);
+    }
+  }
+
+  follow() {
+    const content = this.getCurrent();
+    if (content.next) {
+      this.goto(content.next);
+    }
+  }
+}
+
+function parseNodeBody(body: string, visited: Set<string>): DialogueContent {
+  const lines = body.split(/\r?\n/);
+  const texts: string[] = [];
+  const options: DialogueOption[] = [];
+  let next: string | null = null;
+  let i = 0;
+
+  // gather dialogue lines until options or jump
+  while (i < lines.length) {
+    const trimmed = lines[i].trim();
+    if (trimmed.startsWith('->')) break;
+    if (trimmed.startsWith('<<')) {
+      const m = trimmed.match(/<<\s*jump\s+([A-Za-z0-9_]+)\s*>>/);
+      if (m) {
+        next = m[1];
+      }
+      i++;
+      continue;
+    }
+    if (trimmed) texts.push(lines[i]);
+    i++;
+  }
+
+  // parse options
+  for (; i < lines.length; i++) {
+    const trimmed = lines[i].trim();
+    if (!trimmed) continue;
+    if (trimmed.startsWith('->')) {
+      let text = trimmed.slice(2).trim();
+      // check for gating condition {Node}
+      const gateMatch = text.match(/^\{([^}]+)\}\s*(.*)/);
+      if (gateMatch) {
+        const condition = gateMatch[1];
+        text = gateMatch[2].trim();
+        if (!visited.has(condition)) {
+          // skip option if condition not met
+          // also skip the following line with jump
+          if (i + 1 < lines.length && lines[i + 1].trim().startsWith('<<')) i++;
+          continue;
+        }
+      }
+      let target: string | null = null;
+      if (i + 1 < lines.length) {
+        const jumpMatch = lines[i + 1].trim().match(/<<\s*jump\s+([A-Za-z0-9_]+)\s*>>/);
+        if (jumpMatch) {
+          target = jumpMatch[1];
+          i++; // consume jump line
+        }
+      }
+      options.push({ text, target });
+    }
+  }
+  return { lines: texts, options, next };
+}
+

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,8 @@ import { parseFrames, Frame } from './frame-utils';
 import overlordData from './data/Overlord.json';
 import overlordImg from './data/Overlord.png';
 import cryoroomImg from './data/0_cryoroom.png';
+import cryoDialogue from './dialogue/0_cryoroom.yarn?raw';
+import { DialogManager } from './dialog-manager';
 
 const canvas = document.getElementById('game') as HTMLCanvasElement;
 const ctx = canvas.getContext('2d')!;
@@ -55,6 +57,40 @@ Promise.all([
     canvas.style.height = canvas.height * scale + 'px';
   }
   window.addEventListener('resize', resizeCanvas);
-  resizeCanvas();  
+  resizeCanvas();
   requestAnimationFrame(draw);
+
+  const dialogBox = document.getElementById('dialogue') as HTMLDivElement;
+  const textEl = document.getElementById('dialogue-text') as HTMLDivElement;
+  const optionsEl = document.getElementById('dialogue-options') as HTMLDivElement;
+  const manager = new DialogManager(cryoDialogue);
+  manager.start('CryoRoom_Intro');
+
+  function renderDialog() {
+    const content = manager.getCurrent();
+    textEl.innerHTML = content.lines.map(l => `<p>${l}</p>`).join('');
+    optionsEl.innerHTML = '';
+    if (content.options.length > 0) {
+      content.options.forEach((opt, idx) => {
+        const btn = document.createElement('button');
+        btn.textContent = opt.text;
+        btn.onclick = () => {
+          manager.choose(idx);
+          renderDialog();
+        };
+        optionsEl.appendChild(btn);
+      });
+    } else if (content.next) {
+      const btn = document.createElement('button');
+      btn.textContent = 'Next';
+      btn.onclick = () => {
+        manager.follow();
+        renderDialog();
+      };
+      optionsEl.appendChild(btn);
+    }
+    dialogBox.style.display = content.lines.length === 0 && !content.next && content.options.length === 0 ? 'none' : 'block';
+  }
+
+  renderDialog();
 });


### PR DESCRIPTION
## Summary
- import raw yarn file in the main game
- add `DialogManager` to manage dialogue progress
- render dialog text and options in a UI overlay

## Testing
- `npm test`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6875ced252f4832bb541971d48ec287d