### PR TITLE
Wrap canvas and dialogue

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,17 +8,23 @@
       margin: 0;
       background: #000;
     }
+    #game-container {
+      position: relative;
+      width: fit-content;
+      margin: auto;
+    }
     canvas {
       display: block;
-      margin: auto;
     }
   </style>
 </head>
 <body>
-  <canvas id="game"></canvas>
-  <div id="dialogue" style="position:absolute;bottom:0;left:0;width:100%;background:rgba(0,0,0,0.8);color:#fff;font-family:sans-serif;padding:10px;">
-    <div id="dialogue-text"></div>
-    <div id="dialogue-options" style="margin-top:8px;"></div>
+  <div id="game-container">
+    <canvas id="game"></canvas>
+    <div id="dialogue" style="position:absolute;bottom:0;left:0;width:100%;background:rgba(0,0,0,0.8);color:#fff;font-family:sans-serif;padding:10px;">
+      <div id="dialogue-text"></div>
+      <div id="dialogue-options" style="margin-top:8px;"></div>
+    </div>
   </div>
   <script type="module" src="/src/main.ts"></script>
 </body>

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import cryoDialogue from './dialogue/0_cryoroom.yarn?raw';
 import { DialogManager } from './dialog-manager';
 
 const canvas = document.getElementById('game') as HTMLCanvasElement;
+const container = document.getElementById('game-container') as HTMLDivElement;
 const ctx = canvas.getContext('2d')!;
 
 const spriteSheet = new Image();
@@ -53,8 +54,12 @@ Promise.all([
       window.innerWidth / canvas.width,
       window.innerHeight / canvas.height
     );
-    canvas.style.width = canvas.width * scale + 'px';
-    canvas.style.height = canvas.height * scale + 'px';
+    const w = canvas.width * scale;
+    const h = canvas.height * scale;
+    canvas.style.width = w + 'px';
+    canvas.style.height = h + 'px';
+    container.style.width = w + 'px';
+    container.style.height = h + 'px';
   }
   window.addEventListener('resize', resizeCanvas);
   resizeCanvas();


### PR DESCRIPTION
## Summary
- keep dialogue overlay within canvas bounds
- track the surrounding container in `main.ts`
- scale container alongside canvas

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6875d1571e3c832b8e1a22f7f3683479