### PR TITLE
Animate dialogue lines

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,14 +16,40 @@
     canvas {
       display: block;
     }
+    #dialogue {
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      width: 100%;
+      background: rgba(0,0,0,0.8);
+      color: #fff;
+      font-family: sans-serif;
+      padding: 10px;
+      transform: translateY(100%);
+      transition: transform 0.3s ease-out;
+    }
+    #dialogue.visible {
+      transform: translateY(0);
+    }
+    #dialogue-text p {
+      opacity: 0;
+      transition: opacity 0.3s;
+      margin: 0 0 4px 0;
+    }
+    #dialogue-text p.visible {
+      opacity: 1;
+    }
+    #dialogue-options {
+      margin-top: 8px;
+    }
   </style>
 </head>
 <body>
   <div id="game-container">
     <canvas id="game"></canvas>
-    <div id="dialogue" style="position:absolute;bottom:0;left:0;width:100%;background:rgba(0,0,0,0.8);color:#fff;font-family:sans-serif;padding:10px;">
+    <div id="dialogue">
       <div id="dialogue-text"></div>
-      <div id="dialogue-options" style="margin-top:8px;"></div>
+      <div id="dialogue-options"></div>
     </div>
   </div>
   <script type="module" src="/src/main.ts"></script>

--- a/src/main.ts
+++ b/src/main.ts
@@ -71,10 +71,29 @@ Promise.all([
   const manager = new DialogManager(cryoDialogue);
   manager.start('CryoRoom_Intro');
 
-  function renderDialog() {
+  async function renderDialog() {
     const content = manager.getCurrent();
-    textEl.innerHTML = content.lines.map(l => `<p>${l}</p>`).join('');
+    if (content.lines.length === 0 && !content.next && content.options.length === 0) {
+      dialogBox.classList.remove('visible');
+      dialogBox.style.display = 'none';
+      return;
+    }
+
+    dialogBox.style.display = 'block';
+    requestAnimationFrame(() => dialogBox.classList.add('visible'));
+
+    textEl.innerHTML = '';
     optionsEl.innerHTML = '';
+
+    for (const line of content.lines) {
+      const p = document.createElement('p');
+      p.textContent = line;
+      textEl.appendChild(p);
+      // allow CSS transition
+      requestAnimationFrame(() => p.classList.add('visible'));
+      await new Promise(res => setTimeout(res, 600));
+    }
+
     if (content.options.length > 0) {
       content.options.forEach((opt, idx) => {
         const btn = document.createElement('button');
@@ -94,7 +113,6 @@ Promise.all([
       };
       optionsEl.appendChild(btn);
     }
-    dialogBox.style.display = content.lines.length === 0 && !content.next && content.options.length === 0 ? 'none' : 'block';
   }
 
   renderDialog();


### PR DESCRIPTION
## Summary
- add slide-in and fade-in CSS for the dialogue box
- show each line of dialogue sequentially with a fade effect

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6875d2634cf8832b8be45e4befdced7d