### PR TITLE
Highlight visited dialogue options

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,6 +42,9 @@
     #dialogue-options {
       margin-top: 8px;
     }
+    #dialogue-options button.visited {
+      opacity: 0.6;
+    }
   </style>
 </head>
 <body>

--- a/src/dialog-manager.ts
+++ b/src/dialog-manager.ts
@@ -1,6 +1,7 @@
 export interface DialogueOption {
   text: string;
   target: string | null;
+  visited?: boolean;
 }
 
 export interface DialogueContent {
@@ -54,7 +55,7 @@ export class DialogManager {
   }
 }
 
-function parseNodeBody(body: string, visited: Set<string>): DialogueContent {
+function parseNodeBody(body: string, visitedNodes: Set<string>): DialogueContent {
   const lines = body.split(/\r?\n/);
   const texts: string[] = [];
   const options: DialogueOption[] = [];
@@ -88,7 +89,7 @@ function parseNodeBody(body: string, visited: Set<string>): DialogueContent {
       if (gateMatch) {
         const condition = gateMatch[1];
         text = gateMatch[2].trim();
-        if (!visited.has(condition)) {
+        if (!visitedNodes.has(condition)) {
           // skip option if condition not met
           // also skip the following line with jump
           if (i + 1 < lines.length && lines[i + 1].trim().startsWith('<<')) i++;
@@ -103,7 +104,7 @@ function parseNodeBody(body: string, visited: Set<string>): DialogueContent {
           i++; // consume jump line
         }
       }
-      options.push({ text, target });
+      options.push({ text, target, visited: target ? visitedNodes.has(target) : false });
     }
   }
   return { lines: texts, options, next };

--- a/src/main.ts
+++ b/src/main.ts
@@ -98,6 +98,9 @@ Promise.all([
       content.options.forEach((opt, idx) => {
         const btn = document.createElement('button');
         btn.textContent = opt.text;
+        if (opt.visited) {
+          btn.classList.add('visited');
+        }
         btn.onclick = () => {
           manager.choose(idx);
           renderDialog();


### PR DESCRIPTION
## Summary
- mark dialogue options visited in `DialogManager`
- tag visited options with a `visited` CSS class when rendering
- style taken options in the HTML

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6875d5df5bb8832b9d9035f55aef5f92