### PR TITLE
Add keyboard support for Next dialog button

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -72,7 +72,13 @@ Promise.all([
   const manager = new DialogManager(cryoDialogue);
   manager.start('CryoRoom_Intro');
 
+  let nextKeyHandler: ((ev: KeyboardEvent) => void) | null = null;
+
   async function renderDialog() {
+    if (nextKeyHandler) {
+      window.removeEventListener('keydown', nextKeyHandler);
+      nextKeyHandler = null;
+    }
     const content = manager.getCurrent();
     if (content.lines.length === 0 && !content.next && content.options.length === 0) {
       dialogBox.classList.remove('visible');
@@ -120,6 +126,13 @@ Promise.all([
         renderDialog();
       };
       optionsEl.appendChild(btn);
+      nextKeyHandler = (ev: KeyboardEvent) => {
+        if (ev.key === ' ' || ev.key === 'Enter') {
+          ev.preventDefault();
+          btn.click();
+        }
+      };
+      window.addEventListener('keydown', nextKeyHandler);
     }
   }
 


### PR DESCRIPTION
## Summary
- allow pressing space/enter to activate the dialogue "Next" button

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6875d64cba9c832bbd70e983bd3f4e9d