### PR TITLE
Add Phoenix Wright style choice overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,23 @@
       font-weight: bold;
       background: rgba(0,0,0,0.5);
     }
+    #choice-overlay {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      text-align: center;
+      display: none;
+    }
+    #choice-overlay.visible {
+      display: block;
+    }
+    #choice-overlay button {
+      display: block;
+      margin: 8px auto;
+      padding: 8px 16px;
+      font-size: 1.1em;
+    }
   </style>
 </head>
 <body>
@@ -60,6 +77,7 @@
       <div id="dialogue-text"></div>
       <div id="dialogue-options"></div>
     </div>
+    <div id="choice-overlay"></div>
   </div>
   <script type="module" src="/src/main.ts"></script>
 </body>

--- a/src/main.ts
+++ b/src/main.ts
@@ -68,6 +68,7 @@ Promise.all([
   const dialogBox = document.getElementById('dialogue') as HTMLDivElement;
   const textEl = document.getElementById('dialogue-text') as HTMLDivElement;
   const optionsEl = document.getElementById('dialogue-options') as HTMLDivElement;
+  const overlayEl = document.getElementById('choice-overlay') as HTMLDivElement;
   const speakerEl = document.getElementById('dialogue-speaker') as HTMLDivElement;
   const manager = new DialogManager(cryoDialogue);
   manager.start('CryoRoom_Intro');
@@ -85,6 +86,9 @@ Promise.all([
 
     textEl.innerHTML = '';
     optionsEl.innerHTML = '';
+    overlayEl.innerHTML = '';
+    overlayEl.classList.remove('visible');
+    overlayEl.style.display = 'none';
     speakerEl.textContent = '';
 
     for (const line of content.lines) {
@@ -103,14 +107,18 @@ Promise.all([
     }
 
     if (content.options.length > 0) {
+      overlayEl.style.display = 'block';
+      requestAnimationFrame(() => overlayEl.classList.add('visible'));
       content.options.forEach((opt, idx) => {
         const btn = document.createElement('button');
         btn.textContent = opt.text;
         btn.onclick = () => {
+          overlayEl.classList.remove('visible');
+          overlayEl.style.display = 'none';
           manager.choose(idx);
           renderDialog();
         };
-        optionsEl.appendChild(btn);
+        overlayEl.appendChild(btn);
       });
     } else if (content.next) {
       const btn = document.createElement('button');


### PR DESCRIPTION
## Summary
- show dialogue choice overlay centered on screen
- keep previous dialogue visible during branching options

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6875d6c6b828832b9019be6b81165f7d