### PR TITLE
Preserve last dialog line when showing choices

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,6 +64,9 @@
     #choice-overlay.visible {
       display: block;
     }
+    #choice-overlay p {
+      margin-bottom: 12px;
+    }
     #choice-overlay button {
       display: block;
       margin: 8px auto;

--- a/src/main.ts
+++ b/src/main.ts
@@ -112,9 +112,16 @@ Promise.all([
       await new Promise(res => setTimeout(res, 600));
     }
 
+    const lastLine = textEl.lastElementChild?.textContent ?? '';
+
     if (content.options.length > 0) {
       overlayEl.style.display = 'block';
       requestAnimationFrame(() => overlayEl.classList.add('visible'));
+      if (lastLine) {
+        const p = document.createElement('p');
+        p.textContent = lastLine;
+        overlayEl.appendChild(p);
+      }
       content.options.forEach((opt, idx) => {
         const btn = document.createElement('button');
         btn.textContent = opt.text;


### PR DESCRIPTION
## Summary
- show last displayed line again above the choice buttons
- style the overlay line in the CSS

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6875d90692e8832b8961861203e11a74