### PR TITLE
Fix mobile scaling issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,17 +2,20 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Tropolis</title>
   <style>
     body {
       margin: 0;
+      padding: env(safe-area-inset, 0);
       background: #000;
     }
     #game-container {
       position: relative;
       width: fit-content;
       margin: auto;
+      max-width: 100%;
+      max-height: 100vh;
     }
     canvas {
       display: block;

--- a/src/main.ts
+++ b/src/main.ts
@@ -50,18 +50,21 @@ Promise.all([
   canvas.width = background.width;
   canvas.height = background.height;
   function resizeCanvas() {
+    const vw = window.visualViewport?.width ?? window.innerWidth;
+    const vh = window.visualViewport?.height ?? window.innerHeight;
     const scale = Math.min(
-      window.innerWidth / canvas.width,
-      window.innerHeight / canvas.height
+      vw / canvas.width,
+      vh / canvas.height
     );
-    const w = canvas.width * scale;
-    const h = canvas.height * scale;
+    const w = Math.floor(canvas.width * scale);
+    const h = Math.floor(canvas.height * scale);
     canvas.style.width = w + 'px';
     canvas.style.height = h + 'px';
     container.style.width = w + 'px';
     container.style.height = h + 'px';
   }
   window.addEventListener('resize', resizeCanvas);
+  window.visualViewport?.addEventListener('resize', resizeCanvas);
   resizeCanvas();
   requestAnimationFrame(draw);
 


### PR DESCRIPTION
## Summary
- tweak viewport meta tag and add safe-area padding
- ensure resize logic uses visual viewport dimensions

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6875de367490832b9c968b12efb2dbb7