### PR TITLE
Add keyboard controls for dialogue options

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,6 +80,10 @@
       font-size: 1.1em;
       box-sizing: border-box;
     }
+    #dialogue-options button.selected,
+    #choice-overlay button.selected {
+      outline: 2px solid #fff;
+    }
   </style>
 </head>
 <body>

--- a/src/main.ts
+++ b/src/main.ts
@@ -122,6 +122,7 @@ Promise.all([
         p.textContent = lastLine;
         overlayEl.appendChild(p);
       }
+      const buttons: HTMLButtonElement[] = [];
       content.options.forEach((opt, idx) => {
         const btn = document.createElement('button');
         btn.textContent = opt.text;
@@ -135,7 +136,35 @@ Promise.all([
           renderDialog();
         };
         overlayEl.appendChild(btn);
+        buttons.push(btn);
       });
+      let selected = 0;
+      const updateSelected = () => {
+        buttons.forEach((b, i) => {
+          if (i === selected) {
+            b.classList.add('selected');
+            b.focus();
+          } else {
+            b.classList.remove('selected');
+          }
+        });
+      };
+      updateSelected();
+      nextKeyHandler = (ev: KeyboardEvent) => {
+        if (ev.key === 'ArrowUp') {
+          ev.preventDefault();
+          selected = (selected + buttons.length - 1) % buttons.length;
+          updateSelected();
+        } else if (ev.key === 'ArrowDown') {
+          ev.preventDefault();
+          selected = (selected + 1) % buttons.length;
+          updateSelected();
+        } else if (ev.key === ' ' || ev.key === 'Enter') {
+          ev.preventDefault();
+          buttons[selected].click();
+        }
+      };
+      window.addEventListener('keydown', nextKeyHandler);
     } else if (content.next) {
       const btn = document.createElement('button');
       btn.textContent = 'Next';


### PR DESCRIPTION
## Summary
- allow navigating dialogue choices with up/down arrow keys
- select an option with space or enter
- highlight the selected choice via CSS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6875de76184c832ba12daa8e3eff4aac