### PR TITLE
Add transition when selecting dialogue options

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,9 +69,15 @@
       text-align: center;
       display: none;
       width: 100%;
+      opacity: 0;
+      transition: opacity 0.2s;
     }
     #choice-overlay.visible {
       display: block;
+      opacity: 1;
+    }
+    #choice-overlay.leaving {
+      opacity: 0;
     }
     #choice-overlay p {
       margin-bottom: 12px;

--- a/src/main.ts
+++ b/src/main.ts
@@ -97,6 +97,7 @@ Promise.all([
     optionsEl.innerHTML = '';
     overlayEl.innerHTML = '';
     overlayEl.classList.remove('visible');
+    overlayEl.classList.remove('leaving');
     overlayEl.style.display = 'none';
     speakerEl.textContent = '';
 
@@ -118,6 +119,7 @@ Promise.all([
     const lastLine = textEl.lastElementChild?.textContent ?? '';
 
     if (content.options.length > 0) {
+      overlayEl.classList.remove('leaving');
       overlayEl.style.display = 'block';
       requestAnimationFrame(() => overlayEl.classList.add('visible'));
       if (lastLine) {
@@ -133,10 +135,15 @@ Promise.all([
           btn.classList.add('visited');
         }
         btn.onclick = () => {
-          overlayEl.classList.remove('visible');
-          overlayEl.style.display = 'none';
-          manager.choose(idx);
-          renderDialog();
+          btn.classList.add('selected');
+          overlayEl.classList.add('leaving');
+          setTimeout(() => {
+            overlayEl.classList.remove('visible');
+            overlayEl.classList.remove('leaving');
+            overlayEl.style.display = 'none';
+            manager.choose(idx);
+            renderDialog();
+          }, 200);
         };
         overlayEl.appendChild(btn);
         buttons.push(btn);


### PR DESCRIPTION
## Summary
- add CSS transitions for the choice overlay
- fade out overlay after an option is chosen

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6875ea1d9870832b8c8dc4ed41c0f7f7