### PR TITLE
Add Tower of Hanoi puzzle loader

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,6 +102,34 @@
     #choice-overlay button.selected {
       box-shadow: inset 0 0 0 2px #fff;
     }
+    #puzzle-container {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      display: flex;
+      align-items: flex-end;
+      justify-content: space-around;
+      padding-bottom: 20px;
+      box-sizing: border-box;
+    }
+    .peg {
+      position: relative;
+      width: 20%;
+      height: 80%;
+      border-bottom: 4px solid #fff;
+      display: flex;
+      flex-direction: column-reverse;
+      align-items: center;
+    }
+    .disk {
+      height: 20px;
+      margin: 2px 0;
+      background: #888;
+      border: 1px solid #fff;
+      box-sizing: border-box;
+    }
   </style>
 </head>
 <body>
@@ -113,6 +141,7 @@
       <div id="dialogue-options"></div>
     </div>
     <div id="choice-overlay"></div>
+    <div id="puzzle-container" style="display:none;"></div>
   </div>
   <script type="module" src="/src/main.ts"></script>
 </body>

--- a/src/dialog-manager.test.ts
+++ b/src/dialog-manager.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { DialogManager } from './dialog-manager';
+
+const sample = `title: TestNode
+---
+Overlord: Begin
+<<loadPuzzle TowerOfHanoi>>
+===`;
+
+describe('DialogManager loadPuzzle command', () => {
+  it('parses loadPuzzle command from yarn node', () => {
+    const dm = new DialogManager(sample);
+    dm.start('TestNode');
+    const content = dm.getCurrent();
+    expect(content.command).toEqual({ name: 'loadPuzzle', args: ['TowerOfHanoi'] });
+  });
+});

--- a/src/dialogue/0_cryoroom.yarn
+++ b/src/dialogue/0_cryoroom.yarn
@@ -39,6 +39,8 @@ title: LetsContinue
 Overlord: Good. Your first task is to repair the power grid in Sector 7.
 Overlord: The maintenance tunnels will take you there safely.
 Overlord: Be careful - some areas may still be unstable.
+Overlord: Before you go, prove your focus with a simple test.
+Overlord: Move all five rings to the far right peg without placing a larger ring on top of a smaller one.
 <<loadPuzzle TowerOfHanoi>>
 ===
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import overlordImg from './data/Overlord.png';
 import cryoroomImg from './data/0_cryoroom.png';
 import cryoDialogue from './dialogue/0_cryoroom.yarn?raw';
 import { DialogManager } from './dialog-manager';
+import { startTowerOfHanoi } from './puzzles';
 
 const canvas = document.getElementById('game') as HTMLCanvasElement;
 const container = document.getElementById('game-container') as HTMLDivElement;
@@ -72,6 +73,7 @@ Promise.all([
   const textEl = document.getElementById('dialogue-text') as HTMLDivElement;
   const optionsEl = document.getElementById('dialogue-options') as HTMLDivElement;
   const overlayEl = document.getElementById('choice-overlay') as HTMLDivElement;
+  const puzzleEl = document.getElementById('puzzle-container') as HTMLDivElement;
   const speakerEl = document.getElementById('dialogue-speaker') as HTMLDivElement;
   const manager = new DialogManager(cryoDialogue);
   manager.start('CryoRoom_Intro');
@@ -190,6 +192,16 @@ Promise.all([
         }
       };
       window.addEventListener('keydown', nextKeyHandler);
+    }
+
+    if (content.command) {
+      if (content.command.name === 'loadPuzzle') {
+        puzzleEl.style.display = 'flex';
+        dialogBox.style.display = 'none';
+        if (content.command.args[0] === 'TowerOfHanoi') {
+          startTowerOfHanoi(puzzleEl, 5);
+        }
+      }
     }
   }
 

--- a/src/puzzles/index.ts
+++ b/src/puzzles/index.ts
@@ -1,0 +1,1 @@
+export { startTowerOfHanoi } from './tower-of-hanoi';

--- a/src/puzzles/tower-of-hanoi.ts
+++ b/src/puzzles/tower-of-hanoi.ts
@@ -1,0 +1,59 @@
+export function startTowerOfHanoi(container: HTMLElement, count = 5) {
+  container.innerHTML = '';
+  container.style.display = 'flex';
+
+  const pegs: number[][] = [[], [], []];
+  for (let i = count; i >= 1; i--) pegs[0].push(i);
+
+  const selected: { disk: number | null; from: number | null } = { disk: null, from: null };
+
+  const pegEls: HTMLDivElement[] = [];
+
+  function render() {
+    pegEls.forEach((pegEl, idx) => {
+      pegEl.innerHTML = '';
+      const disks = pegs[idx];
+      disks.forEach(d => {
+        const disk = document.createElement('div');
+        disk.className = 'disk';
+        disk.style.width = 20 + d * 20 + 'px';
+        disk.dataset.size = String(d);
+        pegEl.appendChild(disk);
+      });
+    });
+  }
+
+  function onPegClick(idx: number) {
+    const peg = pegs[idx];
+    if (selected.disk === null) {
+      if (peg.length === 0) return;
+      selected.disk = peg.pop()!;
+      selected.from = idx;
+    } else {
+      const top = peg[peg.length - 1] ?? Infinity;
+      if (selected.disk < top) {
+        peg.push(selected.disk);
+        selected.disk = null;
+        selected.from = null;
+        if (pegs[2].length === count) {
+          alert('Puzzle complete!');
+        }
+      } else if (selected.from !== null) {
+        pegs[selected.from].push(selected.disk);
+        selected.disk = null;
+        selected.from = null;
+      }
+    }
+    render();
+  }
+
+  for (let i = 0; i < 3; i++) {
+    const peg = document.createElement('div');
+    peg.className = 'peg';
+    peg.onclick = () => onPegClick(i);
+    pegEls.push(peg);
+    container.appendChild(peg);
+  }
+
+  render();
+}


### PR DESCRIPTION
## Summary
- support commands in dialogue nodes
- implement `loadPuzzle` command in dialog manager
- hook puzzle loading into the main app and hide dialogue when triggered
- build a simple Tower of Hanoi puzzle and expose it via a new `puzzle-container`
- add puzzle instructions to the cryo room dialogue
- test parsing of the new command

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6875ed92fbbc832b96d5ced66ccb051a