### PR TITLE
Add dialogue validation utilities

### DIFF
--- a/src/dialog-validation.test.ts
+++ b/src/dialog-validation.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { parseYarn, validateYarn } from './yarn-utils';
+import fs from 'fs';
+
+const cryo = fs.readFileSync('src/dialogue/0_cryoroom.yarn', 'utf8');
+const nodes = parseYarn(cryo);
+
+describe('dialogue validation', () => {
+  it('all paths terminate and nodes reachable', () => {
+    const result = validateYarn(nodes, 'CryoRoom_Intro');
+    expect(result.unreachable).toEqual([]);
+    expect(result.nonterminating).toEqual([]);
+  });
+});

--- a/src/dialogue/0_cryoroom.yarn
+++ b/src/dialogue/0_cryoroom.yarn
@@ -59,5 +59,6 @@ Overlord: The important thing is that your skills and knowledge remain intact.
 ===
 
 title: MemoryQuestionAvailable
+tags: disabled
 ---
 ===


### PR DESCRIPTION
## Summary
- tag a disabled gating node
- implement yarn validation utilities
- test that dialogues terminate and nodes are reachable

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6875f07993c4832b9c19d29af3bf03ef