### PR TITLE
Add narrator box border and transparency

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,19 +40,21 @@
     #dialogue-options button.visited {
       opacity: 0.6;
     }
-    #dialogue {
-      position: absolute;
-      bottom: 10px;
-      left: 0;
-      width: 100%;
-      background: rgba(0,0,0,0.8);
-      color: #fff;
-      font-family: sans-serif;
-      padding: 10px;
-      transform: translateY(100%);
-      transition: transform 0.3s ease-out;
-      box-sizing: border-box;
-    }
+      #dialogue {
+        position: absolute;
+        bottom: 10px;
+        left: 0;
+        width: 100%;
+        background: rgba(0,0,0,0.7);
+        color: #fff;
+        font-family: sans-serif;
+        padding: 10px;
+        transform: translateY(100%);
+        transition: transform 0.3s ease-out;
+        box-sizing: border-box;
+        border-top: 2px solid #fff;
+        border-bottom: 2px solid #fff;
+      }
     #dialogue-speaker {
       border: 2px solid #fff;
       display: inline-block;


### PR DESCRIPTION
## Summary
- adjust `#dialogue` styling for narrator text area
  - add white borders at the top and bottom
  - make background a bit more transparent

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6877162fa150832bb672a086c19d91bc