### PR TITLE
Add post-puzzle dialogue

### DIFF
--- a/src/dialogue/0_cryoroom_afterpuzzle.yarn
+++ b/src/dialogue/0_cryoroom_afterpuzzle.yarn
@@ -1,0 +1,28 @@
+title: CryoRoom_AfterPuzzle_Start
+tags: cryo
+---
+Overlord: Well done. You solved the test.
+-> Thanks, that was fun
+    <<jump CryoRoom_AfterPuzzle_Pleased>>
+-> That's a child's toy
+    <<jump CryoRoom_AfterPuzzle_Toy>>
+===
+
+title: CryoRoom_AfterPuzzle_Pleased
+---
+You: Thanks, that was fun.
+Overlord: I'm glad your mind is sharp after cryostasis.
+<<jump CryoRoom_AfterPuzzle_End>>
+===
+
+title: CryoRoom_AfterPuzzle_Toy
+---
+You: That's a child's toy.
+Overlord: It may be simple, but it confirms your cognitive functions survived cryostasis.
+<<jump CryoRoom_AfterPuzzle_End>>
+===
+
+title: CryoRoom_AfterPuzzle_End
+---
+Overlord: Now, let's proceed to Sector 7.
+===

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import overlordData from './data/Overlord.json';
 import overlordImg from './data/Overlord.png';
 import cryoroomImg from './data/0_cryoroom.png';
 import cryoDialogue from './dialogue/0_cryoroom.yarn?raw';
+import cryoAfterPuzzleDialogue from './dialogue/0_cryoroom_afterpuzzle.yarn?raw';
 import { DialogManager } from './dialog-manager';
 import { startTowerOfHanoi } from './puzzles';
 
@@ -75,7 +76,7 @@ Promise.all([
   const overlayEl = document.getElementById('choice-overlay') as HTMLDivElement;
   const puzzleEl = document.getElementById('puzzle-container') as HTMLDivElement;
   const speakerEl = document.getElementById('dialogue-speaker') as HTMLDivElement;
-  const manager = new DialogManager(cryoDialogue);
+  let manager = new DialogManager(cryoDialogue);
   manager.start('CryoRoom_Intro');
 
   let nextKeyHandler: ((ev: KeyboardEvent) => void) | null = null;
@@ -203,7 +204,13 @@ Promise.all([
         puzzleEl.style.display = 'flex';
         dialogBox.style.display = 'none';
         if (content.command.args[0] === 'TowerOfHanoi') {
-          startTowerOfHanoi(puzzleEl, 5);
+          startTowerOfHanoi(puzzleEl, 5, () => {
+            puzzleEl.style.display = 'none';
+            dialogBox.style.display = 'block';
+            manager = new DialogManager(cryoAfterPuzzleDialogue);
+            manager.start('CryoRoom_AfterPuzzle_Start');
+            renderDialog();
+          });
         }
       }
     }

--- a/src/puzzles/tower-of-hanoi.ts
+++ b/src/puzzles/tower-of-hanoi.ts
@@ -1,4 +1,8 @@
-export function startTowerOfHanoi(container: HTMLElement, count = 5) {
+export function startTowerOfHanoi(
+  container: HTMLElement,
+  count = 5,
+  onComplete?: () => void
+) {
   container.innerHTML = '';
   container.style.display = 'flex';
 
@@ -36,7 +40,11 @@ export function startTowerOfHanoi(container: HTMLElement, count = 5) {
         selected.disk = null;
         selected.from = null;
         if (pegs[2].length === count) {
-          alert('Puzzle complete!');
+          if (onComplete) {
+            onComplete();
+          } else {
+            alert('Puzzle complete!');
+          }
         }
       } else if (selected.from !== null) {
         pegs[selected.from].push(selected.disk);


### PR DESCRIPTION
## Summary
- create a new Yarn script for after the cryoroom puzzle
- allow Tower of Hanoi to notify when the puzzle is complete
- import the new script and start it once the puzzle finishes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877172e5c68832b8e5b63ebf590daf0