### PR TITLE
Limit Tower of Hanoi puzzle to four rings

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -203,7 +203,7 @@ Promise.all([
         puzzleEl.style.display = 'flex';
         dialogBox.style.display = 'none';
         if (content.command.args[0] === 'TowerOfHanoi') {
-          startTowerOfHanoi(puzzleEl, 5);
+          startTowerOfHanoi(puzzleEl, 4);
         }
       }
     }

--- a/src/puzzles/tower-of-hanoi.ts
+++ b/src/puzzles/tower-of-hanoi.ts
@@ -1,4 +1,4 @@
-export function startTowerOfHanoi(container: HTMLElement, count = 5) {
+export function startTowerOfHanoi(container: HTMLElement, count = 4) {
   container.innerHTML = '';
   container.style.display = 'flex';
 


### PR DESCRIPTION
## Summary
- default to four rings for Tower of Hanoi
- load the puzzle with four rings instead of five

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_687717c1042c832ba2e5ad87b1ee8067