### PR TITLE
Adjust dialog box size and Next button

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,6 +54,7 @@
         box-sizing: border-box;
         border-top: 2px solid #fff;
         border-bottom: 2px solid #fff;
+        min-height: 6em;
       }
     #dialogue-speaker {
       border: 2px solid #fff;
@@ -99,6 +100,9 @@
       font-size: 1.1em;
       box-sizing: border-box;
       border: 2px solid transparent;
+    }
+    #dialogue-next {
+      width: auto;
     }
     #dialogue-options button.selected,
     #choice-overlay button.selected {

--- a/src/main.ts
+++ b/src/main.ts
@@ -185,6 +185,7 @@ Promise.all([
     } else if (content.next) {
       const btn = document.createElement('button');
       btn.textContent = 'Next';
+      btn.id = 'dialogue-next';
       btn.onclick = () => {
         manager.follow();
         renderDialog();


### PR DESCRIPTION
## Summary
- shrink the Next button width to match its text
- ensure dialog box always displays at least four lines

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68771973443c832b9389ab7313c668a4