### PR TITLE
Add cheat menu to complete puzzle

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,6 +136,31 @@
       border: 1px solid #fff;
       box-sizing: border-box;
     }
+    #cheat-toggle {
+      position: absolute;
+      bottom: 10px;
+      right: 10px;
+      font-size: 1.5em;
+      background: none;
+      border: none;
+      color: #fff;
+      cursor: pointer;
+    }
+    #cheat-menu {
+      position: absolute;
+      bottom: 50px;
+      right: 10px;
+      background: rgba(0,0,0,0.8);
+      color: #fff;
+      padding: 10px;
+      display: none;
+    }
+    #cheat-menu button {
+      display: block;
+      width: 100%;
+      margin-top: 5px;
+      padding: 5px;
+    }
   </style>
 </head>
 <body>
@@ -148,6 +173,10 @@
     </div>
     <div id="choice-overlay"></div>
     <div id="puzzle-container" style="display:none;"></div>
+    <button id="cheat-toggle">⚡</button>
+    <div id="cheat-menu">
+      <button id="cheat-complete-puzzle">Complete Puzzle</button>
+    </div>
   </div>
   <script type="module" src="/src/main.ts"></script>
 </body>

--- a/src/main.ts
+++ b/src/main.ts
@@ -76,6 +76,22 @@ Promise.all([
   const overlayEl = document.getElementById('choice-overlay') as HTMLDivElement;
   const puzzleEl = document.getElementById('puzzle-container') as HTMLDivElement;
   const speakerEl = document.getElementById('dialogue-speaker') as HTMLDivElement;
+  const cheatButton = document.getElementById('cheat-toggle') as HTMLButtonElement;
+  const cheatMenu = document.getElementById('cheat-menu') as HTMLDivElement;
+  const cheatCompleteBtn = document.getElementById('cheat-complete-puzzle') as HTMLButtonElement;
+  let puzzleComplete: (() => void) | null = null;
+
+  cheatButton.onclick = () => {
+    cheatMenu.style.display = cheatMenu.style.display === 'block' ? 'none' : 'block';
+  };
+  cheatCompleteBtn.onclick = () => {
+    if (puzzleComplete) {
+      const cb = puzzleComplete;
+      puzzleComplete = null;
+      cb();
+      cheatMenu.style.display = 'none';
+    }
+  };
   let manager = new DialogManager(cryoDialogue);
   manager.start('CryoRoom_Intro');
   let lineIndex = 0;
@@ -242,13 +258,18 @@ Promise.all([
         puzzleEl.style.display = 'flex';
         dialogBox.style.display = 'none';
         if (content.command.args[0] === 'TowerOfHanoi') {
-          startTowerOfHanoi(puzzleEl, 4, () => {
+          puzzleComplete = () => {
             puzzleEl.style.display = 'none';
             dialogBox.style.display = 'block';
             manager = new DialogManager(cryoAfterPuzzleDialogue);
             manager.start('CryoRoom_AfterPuzzle_Start');
             lineIndex = 0;
             renderDialog();
+          };
+          startTowerOfHanoi(puzzleEl, 4, () => {
+            const cb = puzzleComplete;
+            puzzleComplete = null;
+            cb?.();
           });
         }
       }


### PR DESCRIPTION
## Summary
- add cheat toggle button and menu to HTML
- implement logic in main.ts to trigger puzzle completion

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68771bb4ab20832b853495dc49ba8007