### PR TITLE
Add skip dialogue cheat feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -176,6 +176,7 @@
     <button id="cheat-toggle">⚡</button>
     <div id="cheat-menu">
       <button id="cheat-complete-puzzle">Complete Puzzle</button>
+      <button id="cheat-skip-dialog">Skip Dialogue</button>
     </div>
   </div>
   <script type="module" src="/src/main.ts"></script>


### PR DESCRIPTION
## Summary
- extend cheat menu with a **Skip Dialogue** button
- allow skipping through remaining dialogue via cheat menu
- disable skip button when no dialogue is active

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68771effa66c832b81844b14bfab8b22