### PR TITLE
Add Sector 7 level

### DIFF
--- a/src/dialog-manager.test.ts
+++ b/src/dialog-manager.test.ts
@@ -7,11 +7,26 @@ Overlord: Begin
 <<loadPuzzle TowerOfHanoi>>
 ===`;
 
+const sampleLevel = `title: LevelNode
+---
+Overlord: Proceed
+<<loadLevel Sector7>>
+===`;
+
 describe('DialogManager loadPuzzle command', () => {
   it('parses loadPuzzle command from yarn node', () => {
     const dm = new DialogManager(sample);
     dm.start('TestNode');
     const content = dm.getCurrent();
     expect(content.command).toEqual({ name: 'loadPuzzle', args: ['TowerOfHanoi'] });
+  });
+});
+
+describe('DialogManager loadLevel command', () => {
+  it('parses loadLevel command from yarn node', () => {
+    const dm = new DialogManager(sampleLevel);
+    dm.start('LevelNode');
+    const content = dm.getCurrent();
+    expect(content.command).toEqual({ name: 'loadLevel', args: ['Sector7'] });
   });
 });

--- a/src/dialog-manager.ts
+++ b/src/dialog-manager.ts
@@ -103,6 +103,12 @@ function parseNodeBody(body: string, visitedNodes: Set<string>): DialogueContent
         i++;
         continue;
       }
+      const levelMatch = trimmed.match(/<<\s*loadLevel\s+([A-Za-z0-9_]+)\s*>>/);
+      if (levelMatch) {
+        command = { name: 'loadLevel', args: [levelMatch[1]] };
+        i++;
+        continue;
+      }
       i++;
       continue;
     }

--- a/src/dialogue/0_cryoroom_afterpuzzle.yarn
+++ b/src/dialogue/0_cryoroom_afterpuzzle.yarn
@@ -25,4 +25,5 @@ Overlord: It may be simple, but it confirms your cognitive functions survived cr
 title: CryoRoom_AfterPuzzle_End
 ---
 Overlord: Now, let's proceed to Sector 7.
+<<loadLevel Sector7>>
 ===

--- a/src/dialogue/1_sector7.yarn
+++ b/src/dialogue/1_sector7.yarn
@@ -1,0 +1,7 @@
+title: Sector7_Start
+tags: sector7
+---
+Overlord: Welcome to Sector 7. The main power conduits converge here.
+Overlord: I'll monitor your progress from the control room.
+Overlord: Begin by inspecting the control terminals.
+===

--- a/src/yarn-utils.ts
+++ b/src/yarn-utils.ts
@@ -77,6 +77,12 @@ function parseEdges(body: string): NodeEdges {
       i++;
       continue;
     }
+    const levelMatch = trimmed.match(/<<\s*loadLevel\s+([A-Za-z0-9_]+)\s*>>/);
+    if (levelMatch) {
+      command = 'loadLevel';
+      i++;
+      continue;
+    }
     i++;
   }
 
@@ -101,7 +107,7 @@ export interface YarnValidationResult {
   nonterminating: string[];
 }
 
-export function validateYarn(nodes: YarnNode[], start: string, terminatingCommands: string[] = ['loadPuzzle']): YarnValidationResult {
+export function validateYarn(nodes: YarnNode[], start: string, terminatingCommands: string[] = ['loadPuzzle', 'loadLevel']): YarnValidationResult {
   const nodeMap = new Map<string, YarnNode>();
   for (const n of nodes) nodeMap.set(n.title, n);
 


### PR DESCRIPTION
## Summary
- add Sector 7 dialog
- add `loadLevel` yarn command and parsing
- support `loadLevel` in the game engine
- change after-puzzle dialog to jump to Sector 7
- add tests for new command

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687725016748832b87e294ece9ee46ff