### PR TITLE
Fix animation timing reset

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -42,7 +42,7 @@ function setAnimation(name: string) {
   if (!anim) throw new Error(`Unknown animation ${name}`);
   currentFrames = anim;
   frameIndex = 0;
-  lastSwitch = 0;
+  lastSwitch = performance.now();
 }
 
 function draw(timestamp: number) {


### PR DESCRIPTION
## Summary
- reset animation lastSwitch timestamp using `performance.now()`

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68788a1d5d88832b91e9d99ed93d3a7b