### PR TITLE
Refactor dialog manager handlers

### DIFF
--- a/src/dialog-manager.test.ts
+++ b/src/dialog-manager.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { DialogManager } from './dialog-manager';
 
+const noopHandlers = {
+  loadPuzzle: () => {},
+  loadLevel: () => {}
+};
+
 const sample = `title: TestNode
 ---
 Overlord: Begin
@@ -24,7 +29,7 @@ Overlord: Hi
 
 describe('DialogManager loadPuzzle command', () => {
   it('parses loadPuzzle command from yarn node', () => {
-    const dm = new DialogManager(sample);
+    const dm = new DialogManager(sample, noopHandlers);
     dm.start('TestNode');
     const content = dm.getCurrent();
     expect(content.command).toEqual({ name: 'loadPuzzle', args: ['TowerOfHanoi'] });
@@ -33,7 +38,7 @@ describe('DialogManager loadPuzzle command', () => {
 
 describe('DialogManager loadLevel command', () => {
   it('parses loadLevel command from yarn node', () => {
-    const dm = new DialogManager(sampleLevel);
+    const dm = new DialogManager(sampleLevel, noopHandlers);
     dm.start('LevelNode');
     const content = dm.getCurrent();
     expect(content.command).toEqual({ name: 'loadLevel', args: ['Sector7'] });
@@ -42,12 +47,50 @@ describe('DialogManager loadLevel command', () => {
 
 describe('speaker animation definitions', () => {
   it('loads talk animation for speaker', () => {
-    const dm = new DialogManager(sampleAnim);
+    const dm = new DialogManager(sampleAnim, noopHandlers);
     dm.start('AnimNode');
     expect(dm.getAnimationForSpeaker('Overlord')).toBe('overlordTalk');
   });
   it('throws if speaker not defined', () => {
-    const dm = new DialogManager(sampleAnim);
+    const dm = new DialogManager(sampleAnim, noopHandlers);
     expect(() => dm.getAnimationForSpeaker('Unknown')).toThrow();
+  });
+});
+
+const sampleLines = `title: LinesNode
+---
+A: one
+A: two
+B: three
+===`;
+
+const sampleCmd = `title: CmdNode
+---
+Overlord: Do it
+<<loadPuzzle TowerOfHanoi>>
+===`;
+
+describe('headless dialogue stepping', () => {
+  it('groups lines by speaker', () => {
+    const dm = new DialogManager(sampleLines, noopHandlers);
+    dm.start('LinesNode');
+    const first = dm.nextLines();
+    expect(first).toEqual({ lines: ['A: one', 'A: two'], speaker: 'A' });
+    const second = dm.nextLines();
+    expect(second).toEqual({ lines: ['B: three'], speaker: 'B' });
+    const done = dm.nextLines();
+    expect(done).toBeNull();
+  });
+
+  it('executes command callbacks', () => {
+    const calls: string[] = [];
+    const dm = new DialogManager(sampleCmd, {
+      loadPuzzle: args => calls.push(args[0]),
+      loadLevel: () => {}
+    });
+    dm.start('CmdNode');
+    const lines = dm.nextLines();
+    expect(lines?.speaker).toBe('Overlord');
+    expect(calls).toEqual(['TowerOfHanoi']);
   });
 });


### PR DESCRIPTION
## Summary
- require command callbacks via new `CommandHandlers` type
- use `CommandHandlers` in `main.ts`
- update tests to supply handler stubs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68788c546f94832bb6b3e6a8e44893a7