### PR TITLE
Add character support with Overlord data

### DIFF
--- a/src/character.ts
+++ b/src/character.ts
@@ -1,0 +1,10 @@
+import { Frame } from './frame-utils';
+
+export interface CharacterDef {
+  image: HTMLImageElement;
+  animations: {
+    idle: Frame[];
+    talk: Frame[];
+    [key: string]: Frame[];
+  };
+}

--- a/src/characters/index.ts
+++ b/src/characters/index.ts
@@ -1,0 +1,1 @@
+export { default as Overlord } from './overlord';

--- a/src/characters/overlord.ts
+++ b/src/characters/overlord.ts
@@ -1,0 +1,20 @@
+import { CharacterDef } from '../character';
+import { parseFrames } from '../frame-utils';
+import sheetData from '../data/characters/Overlord/Idle.anim';
+import sheetSrc from '../data/characters/Overlord/Overlord.png';
+
+const image = new Image();
+image.src = sheetSrc;
+
+const frames = parseFrames(sheetData);
+
+const Overlord: CharacterDef = {
+  image,
+  animations: {
+    idle: [frames[0]],
+    talk: frames.slice(1),
+    all: frames
+  }
+};
+
+export default Overlord;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,5 @@
-import { parseFrames, Frame } from './frame-utils';
-import overlordData from './data/characters/Overlord/Idle.anim';
-import overlordImg from './data/characters/Overlord/Overlord.png';
+import { Frame } from './frame-utils';
+import { Overlord } from './characters';
 import cryoroomImg from './data/0_cryoroom.png';
 import cryoDialogue from './dialogue/0_cryoroom.yarn?raw';
 import sector7Img from './data/1_sector7.png';
@@ -12,8 +11,7 @@ const canvas = document.getElementById('game') as HTMLCanvasElement;
 const container = document.getElementById('game-container') as HTMLDivElement;
 const ctx = canvas.getContext('2d')!;
 
-const spriteSheet = new Image();
-spriteSheet.src = overlordImg;
+const spriteSheet = Overlord.image;
 
 interface LevelData {
   image: HTMLImageElement;
@@ -71,10 +69,8 @@ Promise.all([
     l.image.onload = () => res();
   }))
 ]).then(() => {
-  const allFrames = parseFrames(overlordData);
-  animations['overlord'] = allFrames;
-  animations['overlordTalk'] = allFrames.slice(1);
-  animations['overlordIdle'] = [allFrames[0]];
+  animations['overlordTalk'] = Overlord.animations.talk;
+  animations['overlordIdle'] = Overlord.animations.idle;
   setAnimation('overlordIdle');
   canvas.width = background.width;
   canvas.height = background.height;


### PR DESCRIPTION
## Summary
- define `CharacterDef` interface for sprite image and animations
- add Overlord character module providing idle and talk animations
- load Overlord data in `main.ts`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879c752bcc4832bbe813761502b2525