### PR TITLE
Improve OptionsWidget default

### DIFF
--- a/src/OptionsWidget.tsx
+++ b/src/OptionsWidget.tsx
@@ -7,10 +7,15 @@ interface OptionsWidgetProps {
 }
 
 export default function OptionsWidget({ options, onSelect }: OptionsWidgetProps) {
-  const [selectedIndex, setSelectedIndex] = useState(0);
+  const getFirstUnvisited = (opts: DialogueOption[]) => {
+    const idx = opts.findIndex(o => !o.visited);
+    return idx === -1 ? 0 : idx;
+  };
+
+  const [selectedIndex, setSelectedIndex] = useState(() => getFirstUnvisited(options));
 
   useEffect(() => {
-    setSelectedIndex(0);
+    setSelectedIndex(getFirstUnvisited(options));
   }, [options]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- default OptionsWidget selection to the first unvisited option

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c0d03f6a8832bbbb16779f87c3e8c