### PR TITLE
Add ExamineEditor overlay

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import DialogueWidget from './DialogueWidget';
 import OptionsWidget from './OptionsWidget';
 import ActionMenu, { ActionType } from './ActionMenu';
 import { startTowerOfHanoi } from './puzzles';
+import ExamineEditor from './ExamineEditor';
 
 function useViewportSize() {
   const [size, setSize] = useState(() => {
@@ -103,6 +104,7 @@ export default function App() {
   const [animation, setAnimation] = useState<Frame[]>(Overlord.animations.idle);
   const [background] = useState(() => levels.CryoRoom.image);
   const [showPuzzle, setShowPuzzle] = useState(false);
+  const [showExamineEditor, setShowExamineEditor] = useState(false);
   const [showActionMenu, setShowActionMenu] = useState(false);
   const [previousOptions, setPreviousOptions] = useState<DialogueOption[]>([]);
   const puzzleContainerRef = useRef<HTMLDivElement>(null);
@@ -182,7 +184,7 @@ export default function App() {
         }
         break;
       case 'examine':
-        // TODO: Implement examine functionality
+        setShowExamineEditor(true);
         break;
       case 'move':
         // TODO: Implement move functionality
@@ -239,10 +241,13 @@ export default function App() {
     const handleKeyPress = (event: KeyboardEvent) => {
       // Only allow action menu when not in dialogue/options/puzzle
       if (showPuzzle || currentEvent?.type === 'choice' || displayLines.length > 0) return;
-      
+
       if (event.code === 'KeyA' || event.code === 'Space') {
         event.preventDefault();
         setShowActionMenu(true);
+      } else if (event.code === 'KeyE') {
+        event.preventDefault();
+        setShowExamineEditor(prev => !prev);
       }
     };
 
@@ -254,6 +259,14 @@ export default function App() {
   return (
     <div id="game-container" style={{ width: viewportSize.width, height: viewportSize.height }}>
       <GameCanvas frames={animation} background={background} width={viewportSize.width} height={viewportSize.height} />
+      {showExamineEditor && (
+        <ExamineEditor
+          width={viewportSize.width}
+          height={viewportSize.height}
+          background={background}
+          onClose={() => setShowExamineEditor(false)}
+        />
+      )}
       {!showPuzzle && (
         <>
           <DialogueWidget

--- a/src/ExamineEditor.tsx
+++ b/src/ExamineEditor.tsx
@@ -1,0 +1,131 @@
+import React, { useState, useRef } from 'react';
+
+export interface ExamineRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  label: string;
+}
+
+export function exportRectangles(rects: ExamineRect[]): string {
+  return JSON.stringify(rects);
+}
+
+interface ExamineEditorProps {
+  width: number;
+  height: number;
+  background: HTMLImageElement;
+  onClose?: () => void;
+}
+
+export default function ExamineEditor({ width, height, background, onClose }: ExamineEditorProps) {
+  const [rectangles, setRectangles] = useState<ExamineRect[]>([]);
+  const [selected, setSelected] = useState<number | null>(null);
+  const [drawingIndex, setDrawingIndex] = useState<number | null>(null);
+  const [draggingIndex, setDraggingIndex] = useState<number | null>(null);
+  const [start, setStart] = useState<{x: number; y: number} | null>(null);
+  const svgRef = useRef<SVGSVGElement>(null);
+
+  const getPointerPos = (e: React.MouseEvent) => {
+    const rect = svgRef.current!.getBoundingClientRect();
+    return { x: e.clientX - rect.left, y: e.clientY - rect.top };
+  };
+
+  const handleMouseDown = (e: React.MouseEvent) => {
+    const pos = getPointerPos(e);
+    const idx = rectangles.findIndex(r =>
+      pos.x >= r.x && pos.x <= r.x + r.width &&
+      pos.y >= r.y && pos.y <= r.y + r.height
+    );
+    if (idx !== -1) {
+      setSelected(idx);
+      setDraggingIndex(idx);
+      setStart(pos);
+    } else {
+      const newRect: ExamineRect = { x: pos.x, y: pos.y, width: 0, height: 0, label: '' };
+      setRectangles(prev => [...prev, newRect]);
+      const newIndex = rectangles.length;
+      setSelected(newIndex);
+      setDrawingIndex(newIndex);
+      setStart(pos);
+    }
+  };
+
+  const handleMouseMove = (e: React.MouseEvent) => {
+    if (!start) return;
+    const pos = getPointerPos(e);
+    if (draggingIndex !== null) {
+      const dx = pos.x - start.x;
+      const dy = pos.y - start.y;
+      setRectangles(prev => prev.map((r, i) => i === draggingIndex ? { ...r, x: r.x + dx, y: r.y + dy } : r));
+      setStart(pos);
+    } else if (drawingIndex !== null) {
+      setRectangles(prev => prev.map((r, i) => i === drawingIndex ? { ...r, width: pos.x - start.x, height: pos.y - start.y } : r));
+    }
+  };
+
+  const handleMouseUp = () => {
+    setDraggingIndex(null);
+    setDrawingIndex(null);
+    setStart(null);
+  };
+
+  const updateField = (field: keyof ExamineRect, value: string | number) => {
+    if (selected === null) return;
+    setRectangles(prev => prev.map((r, i) => i === selected ? { ...r, [field]: value } : r));
+  };
+
+  const selectedRect = selected !== null ? rectangles[selected] : null;
+
+  return (
+    <div className="examine-editor-overlay" style={{ width, height }}>
+      <svg
+        ref={svgRef}
+        width={width}
+        height={height}
+        onMouseDown={handleMouseDown}
+        onMouseMove={handleMouseMove}
+        onMouseUp={handleMouseUp}
+        style={{ backgroundImage: `url(${background.src})`, backgroundSize: 'cover', cursor: 'crosshair' }}
+      >
+        {rectangles.map((r, i) => (
+          <rect
+            key={i}
+            x={Math.min(r.x, r.x + r.width)}
+            y={Math.min(r.y, r.y + r.height)}
+            width={Math.abs(r.width)}
+            height={Math.abs(r.height)}
+            fill="rgba(255,0,0,0.3)"
+            stroke={i === selected ? 'yellow' : 'red'}
+          />
+        ))}
+      </svg>
+      <div className="examine-editor-panel">
+        {selectedRect ? (
+          <div>
+            <label>
+              x: <input type="number" value={selectedRect.x} onChange={e => updateField('x', Number(e.target.value))} />
+            </label>
+            <label>
+              y: <input type="number" value={selectedRect.y} onChange={e => updateField('y', Number(e.target.value))} />
+            </label>
+            <label>
+              width: <input type="number" value={selectedRect.width} onChange={e => updateField('width', Number(e.target.value))} />
+            </label>
+            <label>
+              height: <input type="number" value={selectedRect.height} onChange={e => updateField('height', Number(e.target.value))} />
+            </label>
+            <label>
+              label: <input type="text" value={selectedRect.label} onChange={e => updateField('label', e.target.value)} />
+            </label>
+          </div>
+        ) : (
+          <div>No rectangle selected</div>
+        )}
+        <button onClick={() => console.log(exportRectangles(rectangles))}>Export</button>
+        {onClose && <button onClick={onClose}>Close</button>}
+      </div>
+    </div>
+  );
+}

--- a/src/examine-editor.test.ts
+++ b/src/examine-editor.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { exportRectangles, ExamineRect } from './ExamineEditor';
+
+describe('exportRectangles', () => {
+  it('returns JSON string of rectangles', () => {
+    const rects: ExamineRect[] = [
+      { x: 1, y: 2, width: 3, height: 4, label: 'a' },
+      { x: 5, y: 6, width: 7, height: 8, label: 'b' }
+    ];
+    const json = exportRectangles(rects);
+    expect(json).toBe(JSON.stringify(rects));
+  });
+});

--- a/src/style.css
+++ b/src/style.css
@@ -354,3 +354,19 @@ canvas {
   transform: translateY(-2px);
   box-shadow: 0 4px 12px rgba(255, 0, 0, 0.3);
 }
+
+/* Examine Editor */
+.examine-editor-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 3000;
+}
+.examine-editor-panel {
+  background: rgba(0,0,0,0.7);
+  color: #fff;
+  padding: 8px;
+}
+.examine-editor-panel label {
+  margin-right: 6px;
+}


### PR DESCRIPTION
## Summary
- implement `ExamineEditor` to draw and edit rectangles over the canvas
- style the examine editor overlay
- wire the editor into `App` with keyboard toggle and action menu
- provide unit test for rectangle export

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d195e62dc832baf4c435b01dfa3e9