### PR TITLE
Enable examining interactable hotspots

### DIFF
--- a/src/ExamineOverlay.tsx
+++ b/src/ExamineOverlay.tsx
@@ -1,0 +1,60 @@
+import React, { useState, useEffect } from 'react';
+import { ExamineRect } from './ExamineEditor';
+
+export function getRectAtPosition(rects: ExamineRect[], x: number, y: number): ExamineRect | null {
+  for (const r of rects) {
+    const minX = Math.min(r.x, r.x + r.width);
+    const maxX = Math.max(r.x, r.x + r.width);
+    const minY = Math.min(r.y, r.y + r.height);
+    const maxY = Math.max(r.y, r.y + r.height);
+    if (x >= minX && x <= maxX && y >= minY && y <= maxY) {
+      return r;
+    }
+  }
+  return null;
+}
+
+interface ExamineOverlayProps {
+  width: number;
+  height: number;
+  rects: ExamineRect[];
+  onExit?: () => void;
+}
+
+export default function ExamineOverlay({ width, height, rects, onExit }: ExamineOverlayProps) {
+  const [hover, setHover] = useState<ExamineRect | null>(null);
+
+  const handleMove = (e: React.MouseEvent<HTMLDivElement>) => {
+    const bounds = (e.currentTarget as HTMLDivElement).getBoundingClientRect();
+    const x = e.clientX - bounds.left;
+    const y = e.clientY - bounds.top;
+    const r = getRectAtPosition(rects, x, y);
+    setHover(r);
+  };
+
+  const handleClick = () => {
+    if (hover) {
+      console.log(`${hover.label} clicked`);
+      if (onExit) onExit();
+    }
+  };
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.code === 'Escape' && onExit) {
+        onExit();
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [onExit]);
+
+  return (
+    <div
+      className="examine-overlay"
+      style={{ width, height, cursor: hover ? 'pointer' : 'default' }}
+      onMouseMove={handleMove}
+      onClick={handleClick}
+    />
+  );
+}

--- a/src/examine-overlay.test.ts
+++ b/src/examine-overlay.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { getRectAtPosition } from './ExamineOverlay';
+import { ExamineRect } from './ExamineEditor';
+
+describe('getRectAtPosition', () => {
+  const rects: ExamineRect[] = [
+    { x: 10, y: 10, width: 20, height: 30, label: 'A' },
+    { x: 50, y: 50, width: 40, height: 40, label: 'B' }
+  ];
+
+  it('returns matching rect for coordinates', () => {
+    const r1 = getRectAtPosition(rects, 15, 20);
+    expect(r1?.label).toBe('A');
+    const r2 = getRectAtPosition(rects, 70, 70);
+    expect(r2?.label).toBe('B');
+  });
+
+  it('returns null when no match', () => {
+    expect(getRectAtPosition(rects, 0, 0)).toBeNull();
+  });
+});

--- a/src/examine/cryoroom.json
+++ b/src/examine/cryoroom.json
@@ -1,0 +1,4 @@
+[
+  {"x": 100, "y": 150, "width": 80, "height": 60, "label": "Console"},
+  {"x": 300, "y": 200, "width": 120, "height": 90, "label": "Door"}
+]

--- a/src/style.css
+++ b/src/style.css
@@ -370,3 +370,11 @@ canvas {
 .examine-editor-panel label {
   margin-right: 6px;
 }
+
+/* Examine Overlay */
+.examine-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 2500;
+}


### PR DESCRIPTION
## Summary
- add JSON hotspot data for the CryoRoom level
- support examine mode with an overlay that detects hotspots
- show/hide overlay from the action menu
- export helper to find a hotspot at coordinates
- style overlay
- test hotspot detection

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_688d186ee464832b9dd6c5741f1867c7