### PR TITLE
Fix options menu during action menu

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -301,11 +301,11 @@ export default function App({ initialLevel = 'CryoRoom' }: AppProps) {
             showNextButton={currentEvent?.type === 'line'}
             onNext={handleNext}
           />
-          <OptionsWidget
+          {showActionMenu && (<OptionsWidget
             options={showActionMenu ? [] : (currentEvent?.type === 'choice' ? currentEvent.options : [])}
             onChoose={handleOptionSelect}
             onEscape={handleOptionsEscape}
-          />
+          />)}
           <ActionMenu
             isVisible={showActionMenu}
             onAction={handleMenuAction}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -302,7 +302,7 @@ export default function App({ initialLevel = 'CryoRoom' }: AppProps) {
             onNext={handleNext}
           />
           {showActionMenu && (<OptionsWidget
-            options={showActionMenu ? [] : (currentEvent?.type === 'choice' ? currentEvent.options : [])}
+            options={currentEvent?.type === 'choice' ? currentEvent.options : []}
             onChoose={handleOptionSelect}
             onEscape={handleOptionsEscape}
           />)}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -302,7 +302,7 @@ export default function App({ initialLevel = 'CryoRoom' }: AppProps) {
             onNext={handleNext}
           />
           <OptionsWidget
-            options={currentEvent?.type === 'choice' ? currentEvent.options : []}
+            options={showActionMenu ? [] : (currentEvent?.type === 'choice' ? currentEvent.options : [])}
             onChoose={handleOptionSelect}
             onEscape={handleOptionsEscape}
           />


### PR DESCRIPTION
## Summary
- prevent OptionsWidget from rendering while the action menu is visible

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688d3c3b001c832bbca5301168d8aa93