### PR TITLE
Enable editor toggle from examine mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -254,6 +254,10 @@ export default function App({ initialLevel = 'CryoRoom' }: AppProps) {
         if (event.code === 'Escape') {
           event.preventDefault();
           setShowExamine(false);
+        } else if (event.code === 'KeyE') {
+          event.preventDefault();
+          setShowExamine(false);
+          setShowExamineEditor(true);
         }
         return;
       }


### PR DESCRIPTION
## Summary
- allow toggling the examine editor while the examine overlay is active

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_688d3c8de0f8832b8d76f2f9a1551c9b