### PR TITLE
Fix options menu during action menu

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -302,7 +302,7 @@ export default function App({ initialLevel = 'CryoRoom' }: AppProps) {
             onNext={handleNext}
           />
           <OptionsWidget
-            options={currentEvent?.type === 'choice' ? currentEvent.options : []}
+            options={showActionMenu ? [] : (currentEvent?.type === 'choice' ? currentEvent.options : [])}
             onChoose={handleOptionSelect}
             onEscape={handleOptionsEscape}
           />

--- a/src/e2e.test.tsx
+++ b/src/e2e.test.tsx
@@ -72,4 +72,32 @@ describe('Game boot', () => {
     dialogueText = document.querySelector('#dialogue p')?.textContent;
     expect(dialogueText).toBe('You chose option 2');
   });
+
+  it('hides options when the action menu is opened', async () => {
+    await act(async () => {
+      ReactDOM.createRoot(document.getElementById('root')!).render(
+        <App initialLevel="Test" />
+      );
+    });
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    // advance to choice
+    await act(async () => {
+      (document.querySelector('#dialogue button') as HTMLButtonElement).click();
+    });
+    await new Promise(r => setTimeout(r, 0));
+
+    // open action menu via Backspace
+    await act(async () => {
+      const evt = new KeyboardEvent('keydown', { code: 'Backspace' });
+      window.dispatchEvent(evt);
+    });
+    await new Promise(r => setTimeout(r, 0));
+
+    const options = document.querySelectorAll('.option-button');
+    expect(options.length).toBe(0);
+    const actions = document.querySelectorAll('.action-button');
+    expect(actions.length).toBe(3);
+  });
 });


### PR DESCRIPTION
## Summary
- prevent OptionsWidget from rendering while the action menu is visible
- add regression test for options hidden when action menu is active

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_688d3c3b001c832bbca5301168d8aa93