### PR TITLE
Hide dialogue UI during examine mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -300,7 +300,7 @@ export default function App({ initialLevel = 'CryoRoom' }: AppProps) {
           onClose={() => setShowExamineEditor(false)}
         />
       )}
-      {!showPuzzle && (
+      {!showPuzzle && !showExamine && (
         <>
           <DialogueWidget
             lines={displayLines}


### PR DESCRIPTION
## Summary
- keep dialogue UI hidden when examining

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688d4625b180832bae4af07bf98f64e7