### PR TITLE
feat: add gab language VS Code extension

### DIFF
--- a/gab-vscode/package-lock.json
+++ b/gab-vscode/package-lock.json
@@ -1,0 +1,40 @@
+{
+  "name": "gab-language",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "gab-language",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@types/vscode": "^1.84.0",
+        "typescript": "^5.8.3"
+      },
+      "engines": {
+        "vscode": "^1.84.0"
+      }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.102.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.102.0.tgz",
+      "integrity": "sha512-V9sFXmcXz03FtYTSUsYsu5K0Q9wH9w9V25slddcxrh5JgORD14LpnOA7ov0L9ALi+6HrTjskLJ/tY5zeRF3TFA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/gab-vscode/package.json
+++ b/gab-vscode/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "gab-language",
+  "displayName": "GAB Language Support",
+  "description": "Syntax highlighting and diagnostics for .gab files",
+  "version": "0.0.1",
+  "engines": { "vscode": "^1.84.0" },
+  "categories": ["Programming Languages"],
+  "activationEvents": ["onLanguage:gab"],
+  "main": "./dist/extension.js",
+  "contributes": {
+    "languages": [
+      { "id": "gab", "extensions": [".gab"], "aliases": ["Gab"] }
+    ],
+    "grammars": [
+      { "language": "gab", "scopeName": "source.gab", "path": "./syntaxes/gab.tmLanguage.json" }
+    ]
+  },
+  "scripts": {
+    "compile": "tsc -p ./",
+    "test": "npm run compile"
+  },
+  "devDependencies": {
+    "@types/vscode": "^1.84.0",
+    "typescript": "^5.8.3"
+  }
+}

--- a/gab-vscode/src/extension.ts
+++ b/gab-vscode/src/extension.ts
@@ -1,0 +1,51 @@
+import * as vscode from 'vscode';
+import { parseGab, validateGab } from './gab-utils';
+
+function refreshDiagnostics(doc: vscode.TextDocument, collection: vscode.DiagnosticCollection) {
+  if (doc.languageId !== 'gab') return;
+  const diagnostics: vscode.Diagnostic[] = [];
+  const text = doc.getText();
+  try {
+    const nodes = parseGab(text);
+    const start = nodes[0]?.title || '';
+    const result = validateGab(nodes, start);
+    const lines = text.split(/\r?\n/);
+    const findLine = (title: string): number => {
+      return lines.findIndex(l => l.startsWith('title:') && l.includes(title));
+    };
+    for (const t of result.unreachable) {
+      const line = findLine(t);
+      if (line !== -1) {
+        const range = new vscode.Range(line, 0, line, lines[line].length);
+        diagnostics.push(new vscode.Diagnostic(range, `Unreachable node: ${t}`, vscode.DiagnosticSeverity.Warning));
+      }
+    }
+    for (const t of result.nonterminating) {
+      const line = findLine(t);
+      if (line !== -1) {
+        const range = new vscode.Range(line, 0, line, lines[line].length);
+        diagnostics.push(new vscode.Diagnostic(range, `Non-terminating node: ${t}`, vscode.DiagnosticSeverity.Warning));
+      }
+    }
+  } catch (err: any) {
+    const msg = err instanceof Error ? err.message : String(err);
+    diagnostics.push(new vscode.Diagnostic(new vscode.Range(0,0,0,1), msg, vscode.DiagnosticSeverity.Error));
+  }
+  collection.set(doc.uri, diagnostics);
+}
+
+export function activate(context: vscode.ExtensionContext) {
+  const collection = vscode.languages.createDiagnosticCollection('gab');
+  context.subscriptions.push(collection);
+
+  if (vscode.window.activeTextEditor) {
+    refreshDiagnostics(vscode.window.activeTextEditor.document, collection);
+  }
+
+  context.subscriptions.push(
+    vscode.workspace.onDidOpenTextDocument(doc => refreshDiagnostics(doc, collection)),
+    vscode.workspace.onDidChangeTextDocument(e => refreshDiagnostics(e.document, collection))
+  );
+}
+
+export function deactivate() {}

--- a/gab-vscode/src/gab-utils.ts
+++ b/gab-vscode/src/gab-utils.ts
@@ -1,0 +1,228 @@
+export interface GabNode {
+  title: string;
+  body: string;
+  metadata: Record<string, string>;
+}
+
+function stripComment(line: string): string {
+  const commentIndex = line.indexOf('#');
+  if (commentIndex === -1) return line;
+  return line.slice(0, commentIndex);
+}
+
+export function parseGab(content: string): GabNode[] {
+  const nodes: GabNode[] = [];
+  const lines = content.split(/\r?\n/);
+  let i = 0;
+
+  while (i < lines.length) {
+    let line = stripComment(lines[i]).trim();
+    if (!line) { i++; continue; }
+    if (line.startsWith('title:')) {
+      const node: GabNode = { title: line.slice(6).trim(), body: '', metadata: {} };
+      i++;
+      // parse metadata until ---
+      let inBody = false;
+      for (; i < lines.length; i++) {
+        const rawLine = lines[i];
+        line = stripComment(rawLine);
+        const trimmed = line.trim();
+        if (!inBody) {
+          if (trimmed === '---') {
+            inBody = true;
+            continue;
+          }
+          const sep = line.indexOf(':');
+          if (sep !== -1) {
+            const key = line.slice(0, sep).trim();
+            const value = line.slice(sep + 1).trim();
+            node.metadata[key] = value;
+            continue;
+          }
+        }
+        if (trimmed === '===') {
+          break;
+        }
+        if (inBody) {
+          if (node.body) node.body += '\n';
+          node.body += line;
+        }
+      }
+      nodes.push(node);
+      // skip until next line after ===
+      while (i < lines.length && lines[i].trim() !== '===') i++;
+      if (i < lines.length) i++; // skip the === line
+    } else {
+      i++;
+    }
+  }
+  return nodes;
+}
+
+export interface Speaker {
+  talkAnim?: string;
+}
+
+export interface GabFile {
+  nodes: GabNode[];
+  speakers: Record<string, Speaker>;
+}
+
+export function parseGabFile(content: string): GabFile {
+  const speakers: Record<string, Speaker> = {};
+  const lines = content.split(/\r?\n/);
+  let i = 0;
+  while (i < lines.length) {
+    const line = stripComment(lines[i]).trim();
+    if (line.startsWith('title:')) break;
+    if (line.startsWith('speaker:')) {
+      const name = line.slice('speaker:'.length).trim();
+      const data: Speaker = {};
+      i++;
+      if (i < lines.length && stripComment(lines[i]).trim() === '---') i++;
+      while (i < lines.length && stripComment(lines[i]).trim() !== '===') {
+        const l = stripComment(lines[i]).trim();
+        if (l) {
+          const parts = l.split(/\s+/);
+          const key = parts[0];
+          const value = parts.slice(1).join(' ');
+          if (key === 'talkAnim') data.talkAnim = value;
+        }
+        i++;
+      }
+      if (i < lines.length && stripComment(lines[i]).trim() === '===') i++;
+      speakers[name] = data;
+      continue;
+    }
+    i++;
+  }
+  const nodes = parseGab(lines.slice(i).join('\n'));
+  return { nodes, speakers };
+}
+
+interface NodeEdges {
+  targets: { target: string; detour: boolean }[];
+  command: string | null;
+}
+
+function parseEdges(body: string): NodeEdges {
+  const lines = body.split(/\r?\n/);
+  const targets: { target: string; detour: boolean }[] = [];
+  let command: string | null = null;
+  let i = 0;
+  while (i < lines.length) {
+    const trimmed = lines[i].trim();
+    if (trimmed.startsWith('->')) break;
+    const cmdMatch = trimmed.match(/<<\s*(jump|detour)\s+([A-Za-z0-9_]+)\s*>>/);
+    if (cmdMatch) {
+      targets.push({ target: cmdMatch[2], detour: cmdMatch[1] === 'detour' });
+      i++;
+      continue;
+    }
+    const puzzleMatch = trimmed.match(/<<\s*loadPuzzle\s+([A-Za-z0-9_]+)\s*>>/);
+    if (puzzleMatch) {
+      command = 'loadPuzzle';
+      i++;
+      continue;
+    }
+    const levelMatch = trimmed.match(/<<\s*loadLevel\s+([A-Za-z0-9_]+)\s*>>/);
+    if (levelMatch) {
+      command = 'loadLevel';
+      i++;
+      continue;
+    }
+    i++;
+  }
+
+  for (; i < lines.length; i++) {
+    const trimmed = lines[i].trim();
+    if (!trimmed) continue;
+    if (trimmed.startsWith('->')) {
+      if (i + 1 < lines.length) {
+        const nextCmd = lines[i + 1].trim().match(/<<\s*(jump|detour)\s+([A-Za-z0-9_]+)\s*>>/);
+        if (nextCmd) {
+          targets.push({ target: nextCmd[2], detour: nextCmd[1] === 'detour' });
+          i++;
+        }
+      }
+    }
+  }
+  return { targets, command };
+}
+
+export interface GabValidationResult {
+  unreachable: string[];
+  nonterminating: string[];
+}
+
+export function validateGab(nodes: GabNode[], start: string, terminatingCommands: string[] = ['loadPuzzle', 'loadLevel']): GabValidationResult {
+  const nodeMap = new Map<string, GabNode>();
+  for (const n of nodes) nodeMap.set(n.title, n);
+
+  const edges = new Map<string, string[]>();
+  const finalNodes = new Set<string>();
+
+  const addEdge = (from: string, to: string) => {
+    if (!edges.has(from)) edges.set(from, []);
+    edges.get(from)!.push(to);
+  };
+
+  for (const n of nodes) {
+    const { targets, command } = parseEdges(n.body);
+    if (command && terminatingCommands.includes(command)) {
+      finalNodes.add(n.title);
+    }
+    for (const t of targets) {
+      addEdge(n.title, t.target);
+      if (t.detour) addEdge(t.target, n.title);
+    }
+  }
+
+  const reachable = new Set<string>();
+  const queue: string[] = [];
+  if (nodeMap.has(start)) queue.push(start);
+  while (queue.length) {
+    const cur = queue.shift()!;
+    if (reachable.has(cur)) continue;
+    reachable.add(cur);
+    for (const to of edges.get(cur) ?? []) {
+      if (!reachable.has(to)) queue.push(to);
+    }
+  }
+
+  const unreachable: string[] = [];
+  for (const n of nodes) {
+    const tags = n.metadata['tags']?.split(',').map(s => s.trim()) ?? [];
+    if (!reachable.has(n.title) && !tags.includes('disabled') && !tags.includes('examine')) {
+      unreachable.push(n.title);
+    }
+    if (tags.includes('final')) finalNodes.add(n.title);
+  }
+
+  const reverse = new Map<string, string[]>();
+  for (const [from, tos] of edges) {
+    for (const to of tos) {
+      if (!reverse.has(to)) reverse.set(to, []);
+      reverse.get(to)!.push(from);
+    }
+  }
+
+  const canReachFinal = new Set<string>(finalNodes);
+  const q = Array.from(finalNodes);
+  while (q.length) {
+    const cur = q.shift()!;
+    for (const prev of reverse.get(cur) ?? []) {
+      if (!canReachFinal.has(prev)) {
+        canReachFinal.add(prev);
+        q.push(prev);
+      }
+    }
+  }
+
+  const nonterminating: string[] = [];
+  for (const n of reachable) {
+    if (!canReachFinal.has(n)) nonterminating.push(n);
+  }
+
+  return { unreachable, nonterminating };
+}

--- a/gab-vscode/syntaxes/gab.tmLanguage.json
+++ b/gab-vscode/syntaxes/gab.tmLanguage.json
@@ -1,0 +1,15 @@
+{
+  "scopeName": "source.gab",
+  "patterns": [
+    { "name": "keyword.other.gab", "match": "\\b(speaker|title)\\b" },
+    { "name": "keyword.operator.arrow.gab", "match": "->" },
+    {
+      "name": "meta.command.gab",
+      "begin": "<<",
+      "end": ">>",
+      "patterns": [
+        { "match": "\\b[A-Za-z0-9_]+\\b", "name": "support.function.gab" }
+      ]
+    }
+  ]
+}

--- a/gab-vscode/tsconfig.json
+++ b/gab-vscode/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "module": "commonjs",
+    "outDir": "dist",
+    "lib": ["es6"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- add VS Code extension scaffolding for .gab files with syntax highlighting
- parse and validate documents to surface warnings for unreachable/non-terminating nodes

## Testing
- `npm test`
- `npx --yes vsce package`


------
https://chatgpt.com/codex/tasks/task_e_688d80ade0a4832bad0d5c240cac23dc