### PR TITLE
Use colon syntax for speaker metadata

### DIFF
--- a/gab-vscode/src/gab-utils.ts
+++ b/gab-vscode/src/gab-utils.ts
@@ -83,10 +83,12 @@ export function parseGabFile(content: string): GabFile {
       while (i < lines.length && stripComment(lines[i]).trim() !== '===') {
         const l = stripComment(lines[i]).trim();
         if (l) {
-          const parts = l.split(/\s+/);
-          const key = parts[0];
-          const value = parts.slice(1).join(' ');
-          if (key === 'talkAnim') data.talkAnim = value;
+          const sep = l.indexOf(':');
+          if (sep !== -1) {
+            const key = l.slice(0, sep).trim();
+            const value = l.slice(sep + 1).trim();
+            if (key === 'talkAnim') data.talkAnim = value;
+          }
         }
         i++;
       }

--- a/src/dialogue-manager.test.ts
+++ b/src/dialogue-manager.test.ts
@@ -147,11 +147,11 @@ Overlord: You chose option 2
     const sampleLines = `
 speaker: Alice
 ---
-talkAnim aliceTalk
+talkAnim: aliceTalk
 ===
 speaker: Bob  
 ---
-talkAnim bobTalk
+talkAnim: bobTalk
 ===
 title: LinesNode
 ---

--- a/src/dialogue/bookstore.gab
+++ b/src/dialogue/bookstore.gab
@@ -1,10 +1,10 @@
 speaker: Overlord
 ---
-talkAnim overlordTalk
+talkAnim: overlordTalk
 ===
 speaker: You
 ---
-talkAnim none
+talkAnim: none
 ===
 title: Bookstore_Start
 tags: bookstore, intro

--- a/src/dialogue/cryoroom.gab
+++ b/src/dialogue/cryoroom.gab
@@ -1,10 +1,10 @@
 speaker: Overlord
 ---
-talkAnim overlordTalk
+talkAnim: overlordTalk
 ===
 speaker: You
 ---
-talkAnim none
+talkAnim: none
 ===
 title: CryoRoom_Intro
 tags: cryo, intro

--- a/src/dialogue/mall.gab
+++ b/src/dialogue/mall.gab
@@ -1,10 +1,10 @@
 speaker: Overlord
 ---
-talkAnim overlordTalk
+talkAnim: overlordTalk
 ===
 speaker: You
 ---
-talkAnim none
+talkAnim: none
 ===
 title: Mall_Start
 tags: mall, intro

--- a/src/dialogue/sector7.gab
+++ b/src/dialogue/sector7.gab
@@ -1,6 +1,6 @@
 speaker: You
 ---
-talkAnim none
+talkAnim: none
 ===
 title: Sector7_Start
 tags: sector7

--- a/src/dialogue/test-choice.gab
+++ b/src/dialogue/test-choice.gab
@@ -1,6 +1,6 @@
 speaker: Overlord
 ---
-talkAnim overlordTalk
+talkAnim: overlordTalk
 ===
 
 title: ChoiceNode

--- a/src/gab-utils.test.ts
+++ b/src/gab-utils.test.ts
@@ -106,7 +106,7 @@ Some dialogue
   it('handles comments in speaker sections', () => {
     const content = `speaker: Overlord # main character
 ---
-talkAnim overlordTalk # animation name
+talkAnim: overlordTalk # animation name
 ===
 title: Start
 ---
@@ -155,11 +155,11 @@ describe('speaker validation', () => {
   it('validates that all referenced speakers are defined', () => {
     const content = `speaker: Alice
 ---
-talkAnim aliceTalk
+talkAnim: aliceTalk
 ===
 speaker: Bob
 ---
-talkAnim bobTalk
+talkAnim: bobTalk
 ===
 title: Conversation
 ---
@@ -175,7 +175,7 @@ Alice: I'm doing well, thanks.
   it('detects undefined speakers', () => {
     const content = `speaker: Alice
 ---
-talkAnim aliceTalk
+talkAnim: aliceTalk
 ===
 title: Conversation
 ---
@@ -194,7 +194,7 @@ Bob: I don't know.
   it('handles speakers with underscores and numbers', () => {
     const content = `speaker: AI_Bot_2
 ---
-talkAnim robotTalk
+talkAnim: robotTalk
 ===
 title: FutureChat
 ---
@@ -211,7 +211,7 @@ User123: This speaker is not defined.
   it('ignores lines that do not match speaker pattern', () => {
     const content = `speaker: Alice
 ---
-talkAnim aliceTalk
+talkAnim: aliceTalk
 ===
 title: Test
 ---
@@ -230,7 +230,7 @@ Some random text without colon
   it('validates speakers across multiple nodes', () => {
     const content = `speaker: Alice
 ---
-talkAnim aliceTalk
+talkAnim: aliceTalk
 ===
 title: Node1
 ---

--- a/src/gab-utils.ts
+++ b/src/gab-utils.ts
@@ -83,10 +83,12 @@ export function parseGabFile(content: string): GabFile {
       while (i < lines.length && stripComment(lines[i]).trim() !== '===') {
         const l = stripComment(lines[i]).trim();
         if (l) {
-          const parts = l.split(/\s+/);
-          const key = parts[0];
-          const value = parts.slice(1).join(' ');
-          if (key === 'talkAnim') data.talkAnim = value;
+          const sep = l.indexOf(':');
+          if (sep !== -1) {
+            const key = l.slice(0, sep).trim();
+            const value = l.slice(sep + 1).trim();
+            if (key === 'talkAnim') data.talkAnim = value;
+          }
         }
         i++;
       }


### PR DESCRIPTION
## Summary
- parse speaker metadata keys using `key: value` format
- update all sample gab files and tests to use colon syntax
- keep VSCode extension parser in sync

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d93a1bb88832bb652dc4f4f5a6e76