### PR TITLE
Allow Esc to open action menu

### DIFF
--- a/src/OptionsWidget.tsx
+++ b/src/OptionsWidget.tsx
@@ -38,6 +38,7 @@ export default function OptionsWidget({ options, onChoose, onEscape }: OptionsWi
           onChoose(selectedIndex);
           break;
         case 'Backspace':
+        case 'Escape':
           event.preventDefault();
           if (onEscape) {
             onEscape();

--- a/src/e2e.test.tsx
+++ b/src/e2e.test.tsx
@@ -73,7 +73,7 @@ describe('Game boot', () => {
     expect(dialogueText).toBe('You chose option 2');
   });
 
-  it('hides options when the action menu is opened', async () => {
+  it('hides options when the action menu is opened with Backspace', async () => {
     await act(async () => {
       ReactDOM.createRoot(document.getElementById('root')!).render(
         <App initialLevel="Test" />
@@ -91,6 +91,34 @@ describe('Game boot', () => {
     // open action menu via Backspace
     await act(async () => {
       const evt = new KeyboardEvent('keydown', { code: 'Backspace' });
+      window.dispatchEvent(evt);
+    });
+    await new Promise(r => setTimeout(r, 0));
+
+    const options = document.querySelectorAll('.option-button');
+    expect(options.length).toBe(0);
+    const actions = document.querySelectorAll('.action-button');
+    expect(actions.length).toBe(3);
+  });
+
+  it('hides options when the action menu is opened with Escape', async () => {
+    await act(async () => {
+      ReactDOM.createRoot(document.getElementById('root')!).render(
+        <App initialLevel="Test" />
+      );
+    });
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    // advance to choice
+    await act(async () => {
+      (document.querySelector('#dialogue button') as HTMLButtonElement).click();
+    });
+    await new Promise(r => setTimeout(r, 0));
+
+    // open action menu via Escape
+    await act(async () => {
+      const evt = new KeyboardEvent('keydown', { code: 'Escape' });
       window.dispatchEvent(evt);
     });
     await new Promise(r => setTimeout(r, 0));


### PR DESCRIPTION
## Summary
- Allow both `Backspace` and `Escape` to open the action menu
- Test that Escape shows the action menu just like Backspace

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d9a196970832b82fbd2cfba27e1a9