### PR TITLE
feat: validate gab node fields

### DIFF
--- a/gab-vscode/src/gab-utils.test.ts
+++ b/gab-vscode/src/gab-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseGab, GabNode, validateGab } from './gab-utils';
+import { parseGab, GabNode, validateGab, GabParseError } from './gab-utils';
 
 describe('gab-vscode linter', () => {
   describe('basic node parsing', () => {
@@ -60,6 +60,12 @@ Speaker1: Third line
       const result = parseGab(content);
       expect(result.length).toBe(1);
       expect(result[0].body).toBe('Speaker1: First line\nSpeaker2: Second line\nSpeaker1: Third line');
+    });
+    it('reports unknown metadata fields', () => {
+      const content = `title: Foo\n tag: bar\n---\n===`;
+      const errors: GabParseError[] = [];
+      parseGab(content, errors);
+      expect(errors).toEqual([{ line: 1, message: "Unknown field 'tag' in node 'Foo'" }]);
     });
   });
 

--- a/src/dialogue/mall.gab
+++ b/src/dialogue/mall.gab
@@ -11,32 +11,32 @@ You: Whoof, this place has seen better days. Better look around and see what we 
 # ================= Examinables =================
 
 title: Mall_Shops
-tag: examine
+tags: examine
 ---
 You: Mostly ruins, but some lights are still on, and odd sounds indicate some automated systems still function.
 ===
 
 title: Mall_Tree
-tag: examine
+tags: examine
 ---
 You: A large tree grows in the center of the mall, its branches reaching up towards the glass ceiling.
 You: It's a reminder of nature's resilience, even in a place like this.
 ===
 
 title: Mall_Upstairs
-tag: examine
+tags: examine
 ---
 You: The upstairs is mostly intact, but it doesn't look too safe. let's try downstairs first.
 ===
 
 title: Mall_Shops2
-tag: examine
+tags: examine
 ---
 You: More shops, stretching off into the distance. Some are still lit, but most are dark and abandoned.
 ===
 
 title: Mall_FoodCourt
-tag: examine
+tags: examine
 ---
 You: The food court is eerily quiet, with overturned chairs and dead screens.
 You: Looks like the last meal was served a long time ago.

--- a/src/gab-utils.test.ts
+++ b/src/gab-utils.test.ts
@@ -32,6 +32,11 @@ describe('parseGab', () => {
     expect(result[1].metadata).toEqual({ position: '0,0' });
     expect(result[1].body).toBe('Next node text');
   });
+
+  it('throws on unknown metadata fields', () => {
+    const content = `title: Foo\n tag: bar\n---\n===`;
+    expect(() => parseGab(content)).toThrow("Unknown field 'tag' in node 'Foo'");
+  });
 });
 
 describe('loadLevel validation', () => {


### PR DESCRIPTION
## Summary
- enforce known metadata fields when parsing .gab nodes
- surface parser errors as VS Code diagnostics
- fix mall dialogue using invalid `tag` field

## Testing
- `npm test`
- `npm --prefix gab-vscode test`


------
https://chatgpt.com/codex/tasks/task_e_688e32beda04832b948d48df46d8db03