### PR TITLE
Support negated dialogue gates for cryo intro

### DIFF
--- a/src/dialogue-manager.test.ts
+++ b/src/dialogue-manager.test.ts
@@ -152,6 +152,39 @@ Bob: I'm doing well, thanks.
     });
   });
 
+  describe('gating conditions', () => {
+    const gatedDialogue = `title: Intro
+---
+{!Intro} Overlord: Welcome
+<<jump Next>>
+===
+title: Next
+---
+Overlord: After
+===`;
+
+    it('shows negated gated line only on first visit', () => {
+      const dm = new DialogueManager(gatedDialogue, noopHandlers);
+
+      dm.start('Intro');
+      let gen = dm.advance();
+      let event = gen.next().value;
+      expect(event.type).toBe('line');
+      expect(event.text).toBe('Welcome');
+
+      event = gen.next().value;
+      expect(event.type).toBe('line');
+      expect(event.text).toBe('After');
+      expect(gen.next().done).toBe(true);
+
+      dm.start('Intro');
+      gen = dm.advance();
+      event = gen.next().value;
+      expect(event.type).toBe('line');
+      expect(event.text).toBe('After');
+    });
+  });
+
   describe('examine node detection', () => {
     const examineDialogue = `title: RegularNode
 ---

--- a/src/dialogue/cryoroom.gab
+++ b/src/dialogue/cryoroom.gab
@@ -9,8 +9,8 @@ talkAnim: none
 title: CryoRoom_Intro
 tags: cryo, intro
 ---
-Overlord: Wake up 11235.
-Overlord: Wake up 11235. The city needs you.
+{!CryoRoom_Intro} Overlord: Wake up 11235.
+{!CryoRoom_Intro} Overlord: Wake up 11235. The city needs you.
 <<jump CryoRoom_Branch>>
 ===
 


### PR DESCRIPTION
## Summary
- allow `{!Node}` gating in dialogue lines and choices
- only show `CryoRoom_Intro` lines on first visit
- test negated gating behavior

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688e48415e9c832b9a51405c0ea6f584