### PR TITLE
Add examine locations for the bar

### DIFF
--- a/src/dialogue/thebar.gab
+++ b/src/dialogue/thebar.gab
@@ -1,0 +1,35 @@
+speaker: You
+---
+talkAnim: none
+===
+
+title: TheBar_Start
+---
+You: The bar smells of old smoke and spilled spirits. Better take a look around.
+===
+
+# ================= Examinables =================
+
+title: TheBar_Counter
+tags: examine
+---
+You: The counter is scarred and sticky, a testament to countless rough nights.
+===
+
+title: TheBar_Jukebox
+tags: examine
+---
+You: A dusty jukebox still hums softly, waiting for someone to drop a coin.
+===
+
+title: TheBar_Patrons
+tags: examine
+---
+You: Empty stools circle the room like ghosts at a wake.
+===
+
+title: TheBar_Door
+tags: examine
+---
+You: The back door hangs ajar, creaking with every breath of wind.
+===

--- a/src/examine/rooms.ts
+++ b/src/examine/rooms.ts
@@ -3,6 +3,7 @@ import { cryoroomExamineRects } from './cryoroom';
 import { mallExamineRects } from './mall';
 import { sector7ExamineRects } from './sector7';
 import { bookstoreExamineRects } from './bookstore';
+import { thebarExamineRects } from './thebar';
 
 export interface RoomExamineData {
   rects: ExamineRect[];
@@ -20,6 +21,9 @@ export const roomExamineData: Record<string, RoomExamineData> = {
   },
   bookstore: {
     rects: bookstoreExamineRects,
+  },
+  thebar: {
+    rects: thebarExamineRects,
   },
 };
 

--- a/src/examine/thebar.ts
+++ b/src/examine/thebar.ts
@@ -1,0 +1,40 @@
+import { ExamineRect } from '../examine';
+
+export const thebarExamineRects: ExamineRect[] = [
+  {
+    x: 200,
+    y: 650,
+    width: 1100,
+    height: 250,
+    type: 'dialogue',
+    level: 'thebar',
+    dialogueNode: 'TheBar_Counter',
+  },
+  {
+    x: 50,
+    y: 300,
+    width: 200,
+    height: 300,
+    type: 'dialogue',
+    level: 'thebar',
+    dialogueNode: 'TheBar_Jukebox',
+  },
+  {
+    x: 600,
+    y: 350,
+    width: 400,
+    height: 200,
+    type: 'dialogue',
+    level: 'thebar',
+    dialogueNode: 'TheBar_Patrons',
+  },
+  {
+    x: 1300,
+    y: 250,
+    width: 200,
+    height: 400,
+    type: 'dialogue',
+    level: 'thebar',
+    dialogueNode: 'TheBar_Door',
+  },
+];


### PR DESCRIPTION
## Summary
- define clickable examine rectangles for The Bar image
- add flavor text dialogue for bar counter, jukebox, patrons, and door
- register The Bar examine data in room configuration

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e4a3e4f10832b8096292832520764