### PR TITLE
Persist visited dialogue nodes via GameState

### DIFF
--- a/src/game-state.test.ts
+++ b/src/game-state.test.ts
@@ -66,4 +66,33 @@ describe('GameState', () => {
     gs.removeItem('key');
     expect(gs.hasItem('key')).toBe(false);
   });
+
+  it('persists visited dialogue nodes across sessions', () => {
+    const gatedLevels: Record<LevelName, LevelData> = {
+      ...levels,
+      cryoroom: {
+        image: new Image(),
+        dialogue:
+          'title: Intro\n---\n{!Intro} Guide: Welcome\n<<jump Next>>\n===\ntitle: Next\n---\nGuide: After\n===',
+        start: 'Intro',
+        examine: [],
+        connections: [],
+      },
+    };
+
+    const gs = new GameState(gatedLevels, 'cryoroom');
+    let gen = gs.getDialogueGenerator()!;
+    let ev = gen.next().value;
+    expect(ev.type).toBe('line');
+    expect(ev.text).toBe('Welcome');
+    ev = gen.next().value;
+    expect(ev.type).toBe('line');
+    expect(ev.text).toBe('After');
+    expect(gen.next().done).toBe(true);
+
+    gen = gs.startDialogue('Intro');
+    ev = gen.next().value;
+    expect(ev.type).toBe('line');
+    expect(ev.text).toBe('After');
+  });
 });

--- a/src/game-state.ts
+++ b/src/game-state.ts
@@ -21,6 +21,7 @@ export class GameState {
 
   inventory = new Set<string>();
   visited = new Set<string>();
+  dialogueVisited: Record<string, boolean> = {};
   flags: Record<string, boolean> = {};
   currentLevel: LevelName = 'test';
 
@@ -35,11 +36,15 @@ export class GameState {
   startDialogue(dialogueId: string): DialogueGenerator {
     const data = this.levels[this.currentLevel];
     if (!data) throw new Error(`Unknown level: ${this.currentLevel}`);
-    const manager = new DialogueManager(data.dialogue, {
-      loadPuzzle: () => {},
-      loadLevel: () => {},
-      return: () => {},
-    });
+    const manager = new DialogueManager(
+      data.dialogue,
+      {
+        loadPuzzle: () => {},
+        loadLevel: () => {},
+        return: () => {},
+      },
+      this.dialogueVisited
+    );
     manager.start(dialogueId);
     this.dialogueGenerator = manager.advance();
     return this.dialogueGenerator;


### PR DESCRIPTION
## Summary
- Allow DialogueManager to accept an external visited-node map
- Store shared visited nodes in GameState and pass it to DialogueManager
- Add regression test ensuring dialogue visit state persists across sessions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e4e669034832b9959a93aca37c00a